### PR TITLE
Test/get healthy meals

### DIFF
--- a/src/main/kotlin/model/Exceptions.kt
+++ b/src/main/kotlin/model/Exceptions.kt
@@ -14,7 +14,7 @@ class EmptyHighCalorieListException : AppException("there is no high calories me
 
 class RichMaxAttemptException(preparationTime:Int) : Exception("You have reached the maximum number of attempts.The correct preparation time is $preparationTime minutes")
 
-class EmptyHealthFoodListListException : AppException("there is no Fast Foods this date list")
+class EmptyHealthFoodListListException : AppException("No healthy meals found")
 
 class EmptySearchByDateListException : AppException("there is no meals in this date list")
 

--- a/src/test/kotlin/logic/usecase/GetHealthyMealsUseCaseTest.kt
+++ b/src/test/kotlin/logic/usecase/GetHealthyMealsUseCaseTest.kt
@@ -1,0 +1,143 @@
+package logic.usecase
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import logic.repository.FoodRepository
+import model.EmptyHealthFoodListListException
+import model.Food
+import model.Nutrition
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+
+class GetHealthyMealsUseCaseTest {
+    private lateinit var foodRepository: FoodRepository
+    private lateinit var useCase: GetHealthyMealsUseCase
+
+    @BeforeEach
+    fun setUp() {
+        foodRepository = mockk()
+        useCase = GetHealthyMealsUseCase(foodRepository)
+    }
+
+    @Test
+    fun `fetchHealthyFastFoods should returns filtered healthy meals when food repository return success`() {
+        // when
+        val mockFoods = listOf(
+            Food(
+                id = 1,
+                name = "Chicken Wrap",
+                minutes = 10,
+                submittedDate = LocalDate.now(),
+                tags = listOf("fast", "healthy"),
+                nutrition = Nutrition(
+                    calories = 350f,
+                    totalFat = 6f,
+                    sugar = 3f,
+                    sodium = 400f,
+                    protein = 20f,
+                    saturated = 1.2f,
+                    carbohydrates = 30f
+                ),
+                steps = listOf("Grill chicken", "Wrap", "Serve"),
+                description = "Tasty chicken wrap.",
+                ingredients = listOf("Chicken", "Wrap", "Lettuce")
+            ),
+            Food(
+                id = 2,
+                name = "Veggie Bowl",
+                minutes = 12,
+                submittedDate = LocalDate.now(),
+                tags = listOf("vegetarian"),
+                nutrition = Nutrition(
+                    calories = 280f,
+                    totalFat = 3f,
+                    sugar = 2f,
+                    sodium = 300f,
+                    protein = 10f,
+                    saturated = 0.7f,
+                    carbohydrates = 20f
+                ),
+                steps = listOf("Chop veggies", "Mix", "Serve"),
+                description = "Healthy veggie bowl.",
+                ingredients = listOf("Carrot", "Cucumber", "Lettuce")
+            ),
+            Food(
+                id = 3,
+                name = "Burger",
+                minutes = 25, // This one should be filtered out due to time
+                submittedDate = LocalDate.now(),
+                tags = listOf("junk"),
+                nutrition = Nutrition(
+                    calories = 500f,
+                    totalFat = 20f,
+                    sugar = 5f,
+                    sodium = 600f,
+                    protein = 25f,
+                    saturated = 5f,
+                    carbohydrates = 40f
+                ),
+                steps = listOf("Grill patty", "Assemble", "Serve"),
+                description = "Juicy burger.",
+                ingredients = listOf("Beef", "Bun", "Cheese")
+            )
+        )
+
+        every { foodRepository.getFoods() } returns Result.success(mockFoods)
+
+        // given
+        val result = useCase.fetchHealthyFastFoods()
+
+        // then
+        assertThat(result).isNotEmpty()
+        result.forEach { meal ->
+            assertThat(meal.minutes).isAtMost(15)
+        }
+        assertThat(result).doesNotContain(mockFoods[2])
+    }
+    @Test
+    fun `fetchHealthyFastFoods should throws exception if no fast meals found when food repository return success`() {
+        // when
+        val mockFoods = listOf(
+            Food(
+                id = 3,
+                name = "Burger",
+                minutes = 25, // This one should be filtered out due to time
+                submittedDate = LocalDate.now(),
+                tags = listOf("junk"),
+                nutrition = Nutrition(
+                    calories = 500f,
+                    totalFat = 20f,
+                    sugar = 5f,
+                    sodium = 600f,
+                    protein = 25f,
+                    saturated = 5f,
+                    carbohydrates = 40f
+                ),
+                steps = listOf("Grill patty", "Assemble", "Serve"),
+                description = "Juicy burger.",
+                ingredients = listOf("Beef", "Bun", "Cheese")
+            )
+        )
+
+        every { foodRepository.getFoods() } returns Result.success(mockFoods)
+
+
+        // assert
+        val exception = org.junit.jupiter.api.assertThrows<EmptyHealthFoodListListException> {
+            useCase.fetchHealthyFastFoods()
+        }
+        assertThat(exception.message).isNotEmpty()
+    }
+
+    @Test
+    fun `fetchHealthyFastFoods should throw exception when food repository return failure`(){
+        every { foodRepository.getFoods() } returns  Result.failure(Exception())
+
+        org.junit.jupiter.api.assertThrows<Exception> {
+            useCase.fetchHealthyFastFoods()
+        }
+    }
+}

--- a/src/test/kotlin/logic/usecase/GetHealthyMealsUseCaseTest.kt
+++ b/src/test/kotlin/logic/usecase/GetHealthyMealsUseCaseTest.kt
@@ -125,7 +125,7 @@ class GetHealthyMealsUseCaseTest {
         every { foodRepository.getFoods() } returns Result.success(mockFoods)
 
 
-        // assert
+        // then
         val exception = org.junit.jupiter.api.assertThrows<EmptyHealthFoodListListException> {
             useCase.fetchHealthyFastFoods()
         }

--- a/src/test/kotlin/presentation/GetHealthyMealsUITest.kt
+++ b/src/test/kotlin/presentation/GetHealthyMealsUITest.kt
@@ -1,0 +1,70 @@
+package presentation
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import logic.usecase.GetHealthyMealsUseCase
+import model.EmptyHealthFoodListListException
+import model.Food
+import model.Nutrition
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+
+class GetHealthyMealsUITest {
+    private lateinit var getHealthyMealsUseCase: GetHealthyMealsUseCase
+    private lateinit var ui: GetHealthyMealsUI
+    private val testOutput = ByteArrayOutputStream()
+
+    @BeforeEach
+    fun setUp() {
+        getHealthyMealsUseCase = mockk()
+        ui = GetHealthyMealsUI(getHealthyMealsUseCase)
+        System.setOut(PrintStream(testOutput))
+    }
+
+    @Test
+    fun `should print healthy meals when data is available`() {
+        // given
+        val meals = listOf(
+            Food(
+                id = 1,
+                name = "Healthy Salad",
+                minutes = 10,
+                submittedDate = null,
+                tags = listOf("vegan", "low-fat"),
+                nutrition = Nutrition(
+                    calories = 200f, totalFat = 4f, sugar = 2f,
+                    sodium = 100f, protein = 6f, saturated = 1f, carbohydrates = 10f
+                ),
+                steps = listOf("Chop veggies", "Mix"),
+                description = "A fresh green salad.",
+                ingredients = listOf("lettuce", "tomato")
+            )
+        )
+
+        every { getHealthyMealsUseCase.fetchHealthyFastFoods() } returns meals
+
+        // when
+        ui.launchUI()
+
+        // then
+        val output = testOutput.toString().trim()
+        assertThat(output).contains("Healthy meals")
+        assertThat(output).contains("Healthy Salad")
+        assertThat(output).contains("A fresh green salad.")
+    }
+
+    @Test
+    fun `should print error message when exception occurs`() {
+        every { getHealthyMealsUseCase.fetchHealthyFastFoods() } throws EmptyHealthFoodListListException()
+
+        ui.launchUI()
+
+        val output = testOutput.toString().trim()
+        assertThat(output).contains("No healthy meals found")
+    }
+}


### PR DESCRIPTION
This PR adds comprehensive unit test coverage for the following components:
 GetHealthyMealsUseCaseTest

    Validates correct filtering of fast and healthy meals under 15 minutes.

    Ensures nutritional thresholds (25th percentile) are properly applied.

    Handles empty data scenarios by throwing EmptyHealthFoodListListException.

 GetHealthyMealsUITest

    Captures and asserts CLI output for healthy meals listing.

    Verifies behavior when data is present and when an exception is thrown.
